### PR TITLE
Proxy x-range header into range header

### DIFF
--- a/test/fixtures/client.js
+++ b/test/fixtures/client.js
@@ -19,7 +19,12 @@ module.exports = function(serverPort) {
   app.use(proxy({
     hostname: 'localhost',
     port: serverPort,
-    protocol: 'http'
+    protocol: 'http',
+    whitelistHeaders: ['bar'],
+    headerTransforms: {
+      'x-range': 'range',
+      'x-bar'  : 'bar'
+    }
   }));
 
   return server;

--- a/test/proxy-test.js
+++ b/test/proxy-test.js
@@ -60,13 +60,25 @@ describe('proxy', function() {
     });
   });
 
-  it('proxies the X-Range header into the range header', function(done) {
+  it('allows additional headers to be configured', function(done) {
     request({
       url: 'http://localhost:' + clientPort + '/api/apps',
-      headers: { 'X-Range': 'foofyfoofoo' }
+      headers: { 'Bar': 'bar' }
+    }, function(err, res) {
+      if (err) throw err;
+      res.headers['bar'].should.eql('bar');
+      done();
+    });
+  });
+
+  it('transforms configured transformed headers', function(done) {
+    request({
+      url: 'http://localhost:' + clientPort + '/api/apps',
+      headers: { 'X-Range': 'foofyfoofoo', 'X-Bar': 'barbybarbar' }
     }, function(err, res) {
       if (err) throw err;
       res.headers['range'].should.eql('foofyfoofoo');
+      res.headers['bar'].should.eql('barbybarbar');
       done();
     });
   });


### PR DESCRIPTION
Have confirmed that this will work for any endpoint that supports ETag header responses with ranges. If/when we merge this, I have the Ember code ready to go that utilizes this.
