### PR TITLE
Add Heroku Button headers to the whitelist

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,9 @@ function getHeaders(req, options) {
     'if-none-match',
     'range',
     'x-heroku-legacy-ids',
-    'x-request-id'
+    'x-request-id',
+    'heroku-deploy-type',
+    'heroku-deploy-source'
   ].concat(options.whitelistHeaders);
 
   return Object.keys(req.headers).reduce(function(headers, header) {


### PR DESCRIPTION
Add `heroku-deploy-source` and `heroku-deploy-type` headers to the whitelist, so they get sent to API, so we could list where the deploys are actually coming from. 

See https://github.com/heroku/dashboard-v6/pull/400.
